### PR TITLE
Update metadata on modification events

### DIFF
--- a/internal/file/pod_event_handler_test.go
+++ b/internal/file/pod_event_handler_test.go
@@ -60,7 +60,7 @@ func (s *PodMetaWriterSuite) Test_ShouldReturnErrorOnFileCreationFailure() {
 	assert.Error(s.T(), err)
 }
 
-func (s *PodMetaWriterSuite) Test_ShouldNotCreateFileOnModifiedEvent() {
+func (s *PodMetaWriterSuite) Test_ShouldCreateFileOnModifiedEvent() {
 	writer := file.NewPodMetaWriter(s.dir, 1*time.Minute, nopLogger())
 	expectedFile := filepath.Join(s.dir, "kube-system_etcd-docker-desktop.meta")
 
@@ -72,7 +72,7 @@ func (s *PodMetaWriterSuite) Test_ShouldNotCreateFileOnModifiedEvent() {
 	err := writer.Handle(event)
 
 	assert.NoError(s.T(), err)
-	assert.False(s.T(), fileExists(expectedFile))
+	assert.FileExists(s.T(), expectedFile)
 }
 
 func (s *PodMetaWriterSuite) Test_ShouldDeleteFileAfterRetention() {


### PR DESCRIPTION
There is a problem that If at the moment of `ADDED` event a pod was still in a Pending state then `containerStatuses` metadata will almost empty.

As a result Fluent Bit will fail to fetch `container_image` and `container_hash` attributes.

The PR fixes it by updating metadata file upon receiving `MODIFIED` event.